### PR TITLE
Clarifications and typos

### DIFF
--- a/assets/stylesheets/_coverage.sass
+++ b/assets/stylesheets/_coverage.sass
@@ -1,0 +1,13 @@
+.product-coverage
+
+  th, td
+    width: 100px
+    text-align: center
+
+
+  .asset
+    text-align: left
+    width: 300px
+
+  .na
+    background-color: $grey-light

--- a/assets/stylesheets/main.sass
+++ b/assets/stylesheets/main.sass
@@ -14,3 +14,4 @@
 @import "_layout"
 @import "_search"
 @import "_intro"
+@import "_coverage"

--- a/guide/concepts/market_data.md
+++ b/guide/concepts/market_data.md
@@ -7,13 +7,13 @@ Market data is a fundamental aspect of a risk system and most calculations perfo
 
 ## Definition
 
-The term "market data   " in Strata refers to any value which is observable in the market or is derived solely from observable market data. 
+The term "market data" in Strata refers to any value which is observable in the market or is derived solely from observable market data.
 
 For example, FX rates and futures prices are observable market data and can be looked up directly from a provider of market data such as Bloomberg or Reuters. 
 
-A calibrated yield curve is an example of non-observable data as it is derived from observable data such as quoted rates and futures prices.
+A calibrated yield curve is an example of non-observable market data as it is derived from observable data such as quoted rates and futures prices.
 
-It is important to note that measures such as present value or PV01 which are calculated for trades or portfolio are not considered to be market data as they are derived from portfolio data as well as market data.
+Measures such as present value or PV01 are distinguished from market data because they are derived from portfolio data as well as market data.
 
 ## Concepts
 
@@ -28,44 +28,35 @@ In Strata, market data values are assembled in advance of any calculations. This
 
 ### Requesting Market Data for Calculations
 
-If market data must be assembled before starting any calculations, it implies that it must be possible to find out what data is required before starting the calculations. The method `CalculationFunction.requirements` provides this information. See "[Adding a New Measure]({{site.baseurl}}/add_measure/)" for details.
+If market data must be assembled before starting any calculations, it implies that it must be possible to find out what data is required before starting the calculations. The method `CalculationFunction.requirements` provides this information. See [Adding a New Measure]({{site.baseurl}}/add_measure) for details.
 
 ### Identifying Market Data
 
-In order for functions to declare the the market data they require and to request it during their calculations, there must be a way to identify market data. This is done using implementations of `MarketDataKey` and `MarketDataId`.
+In order for functions to declare the market data they require and to request it during their calculations, there must be a way to identify market data. This is done using implementations of `MarketDataKey` and `MarketDataId`.
 
 #### Market Data Keys
 
-Market data keys are used by functions to identify a market data value. The type of the market data key identifies the type of the value and the fields of the key identify the value itself. For example, the set of discount factors for USD are identified by an instance of `DiscountFactorsKey` with a currency of USD.
+Market data keys are used by functions to request a piece of market data. The key contains only the information that a function cares about to operate as generically as possible.
 
-If a function needs discount factors for USD it creates a key:
+For example, the function to price a USD swap will need discount factors from a USD discounting curve; therefore, one of its market data requirements will be an instance of `DiscountFactorsKey` with a currency of USD. This can be constructed as shown below:
 
 ```java
 key = DiscountFactorsKey.of(Currency.USD);
 ```
 
+The currency is the only field on this key; together with the type of the key itself, this is all the information the function should have to specify. The precise details of which USD discounting curve is used to satisfy this requirement is a separate problem that is solved by market data IDs. 
+
 The keys are used to build an instance of `FunctionRequirements` in the `requirements` method and to request data from the `CalculationMarketData` argument passed to the `execute` method.
 
 #### Market Data IDs
 
-Market data IDs are very similar to market data keys, but are a system-wide unique identifier. A key is only unique in the context of a particular function.
+Market data IDs are very similar to market data keys, but are used to identify precisely the piece of market data that will be used. They may contain additional fields in order to do this.
 
-For example, a set of discount factors is derived from a discount curve. A discount curve is calibrated as part of a curve group. A curve group is built using observable data from an underlying feed of observable data. There can be multiple curve groups in the system.
-  
-In oder to uniquely identify a set of discount factors the following pieces of information are needed:
-
-* Type (discount factors)
-* Currency
-* Curve group name
-* Market data feed
-
-The class `DiscountFactorsId` contains this information.
+In the example above, a function uses a market data key to request a set of USD discount factors. This keeps things as simple as possible from the function's perspective. However, the USD discount factors are derived from a USD discounting curve, and there may be multiple such curves to choose from (because of multiple _curve groups_). Additionally, the same curve may exist multiple times, having been calibrated from different market observables (perhaps from different sources, or by using observables snapshotted at different points in time). Therefore, two additional fields are needed to identify precisely the USD discount factors to use: the curve group name, and the market data feed details. The _market data rules_ specify these additional fields, and map the market data key (`DiscountFactorsKey`) into a market data ID (`DiscountFactorsID`).
 
 #### Market Data Rules
 
-In order to provide the market data for a calculation the system must know the IDs of the required market data. But the functions return a set of market data keys from the `requirements` method, not IDs. Therefore there must be a step to convert the keys into IDs. This is the job of the `MarketDataRules`.
- 
-Market data rules specify a mapping between market data keys and IDs. Market data rules can be very general and apply to all calculations, for example:
+Market data rules specify a mapping between market data keys and market data IDs. The rules can be very general and apply to all calculations, for example:
 
 > Use the curve group "Default" as the source of all curves
 

--- a/guide/features/product_coverage.md
+++ b/guide/features/product_coverage.md
@@ -7,13 +7,122 @@ permalink: /product_coverage/
 
 Strata 0.7 includes the following product coverage:
 
-| Asset class               | Types                                           | PV    | PV01   | Bucketed PV01 | Gamma PV01 | Par Rate | CS01 | Bucketed CS01 | Cashflows |
-|---------------------------|-------------------------------------------------|:-----:|:------:|:-------------:|:----------:|:--------:|:----:|:-------------:|:---------:|
-| **Swap**                  | Vanilla, OIS, variable notional, cross-currency | {{x}} | {{x}}  |     {{x}}     |   {{x}}    |  {{x}}   |      |               |  {{x}}    |
-| **FRA**                   |                                                 | {{x}} | {{x}}  |     {{x}}     |   {{x}}    |  {{x}}   |      |               |  {{x}}    |
-| **CDS**                   | Single name, index                              | {{x}} | {{x}}  |     {{x}}     |            |          | {{x}}|    {{x}}      |           |
-| **Generic Future**        |                                                 | {{x}} |        |               |            |          |      |               |           |
-| **Generic Future Option** |                                                 | {{x}} |        |               |            |          |      |               |           |
+<table class="product-coverage">
+  <thead>
+    <tr>
+      <th class="asset">Asset class</th>
+      <th>PV</th>
+      <th>PV01</th>
+      <th>Bucketed PV01</th>
+      <th>Gamma PV01</th>
+      <th>Par Rate</th>
+      <th>CS01</th>
+      <th>Bucketed CS01</th>
+      <th>Cashflows</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+    <td class="asset">Vanilla Swap</td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td class="na"></td>
+    <td class="na"></td>
+    <td><i class="fa fa-check"></i></td>
+    </tr>
+  <tr>
+    <td class="asset">OIS</td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td class="na"></td>
+    <td class="na"></td>
+    <td><i class="fa fa-check"></i></td>
+  </tr>
+  <tr>
+    <td class="asset">Variable-Notional Swap</td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td class="na"></td>
+    <td class="na"></td>
+    <td><i class="fa fa-check"></i></td>
+  </tr>
+  <tr>
+    <td class="asset">Cross-Currency Swap</td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td class="na"></td>
+    <td class="na"></td>
+    <td><i class="fa fa-check"></i></td>
+  </tr>
+  <tr>
+  <td class="asset">FRA</td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td class="na"></td>
+    <td class="na"></td>
+    <td><i class="fa fa-check"></i></td>
+  </tr>
+  <tr>
+    <td class="asset">Single-Name CDS</td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td></td>
+    <td></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td class="asset">Index CDS</td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td></td>
+    <td></td>
+    <td><i class="fa fa-check"></i></td>
+    <td><i class="fa fa-check"></i></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td class="asset">Generic Future</td>
+    <td><i class="fa fa-check"></i></td>
+    <td class="na"></td>
+    <td class="na"></td>
+    <td class="na"></td>
+    <td class="na"></td>
+    <td class="na"></td>
+    <td class="na"></td>
+    <td class="na"></td>
+  </tr>
+  <tr>
+    <td class="asset">Generic Future Option</td>
+    <td><i class="fa fa-check"></i></td>
+    <td class="na"></td>
+    <td class="na"></td>
+    <td class="na"></td>
+    <td class="na"></td>
+    <td class="na"></td>
+    <td class="na"></td>
+    <td class="na"></td>
+  </tr>
+  </tbody>
+</table>
 
 A <i class="fa fa-check"></i> for a measure in the coverage grid means:
 

--- a/guide/features/product_coverage.md
+++ b/guide/features/product_coverage.md
@@ -3,8 +3,6 @@ title: Product Coverage
 permalink: /product_coverage/
 ---
 
-{% assign x = '<i class="fa fa-check"></i>' %}
-
 Strata 0.7 includes the following product coverage:
 
 <table class="product-coverage">

--- a/guide/getting_started/command_line_tool.md
+++ b/guide/getting_started/command_line_tool.md
@@ -18,7 +18,7 @@ Strata is different. Although, of course, it ultimately needs the same inputs, a
 Since so many of the inputs that are necessary for pricing common instruments are standard market conventions, Strata provides these as part of the library and offer easy access to them via built-in constants. This includes common indices and their conventions, currencies and currency pairs, and even holiday calendars generated from rules for the common markets and exchanges. While in a production system these could be sourced from elsewhere and supplemented with more unusual or proprietary data, having the most common data built-in and easily accessible significantly lowers the barrier to evaluation and integration.
 
 The command-line tool illustrates this by making full use of the built-in data and conventions to offer simple, command-line access to the Reporting API. Only trades and market data need to be supplied for access to any of Strata's coverage.
-I
+
 ## Obtaining the tool
 
 ### Download

--- a/guide/overview/introduction.md
+++ b/guide/overview/introduction.md
@@ -18,7 +18,7 @@ Strata allows financial systems developers to build or enhance existing applicat
 
 Strata has been built from the ground up to be lightweight and flexible. It does not impose any database, server or middleware requirements; these would be built on top of Strata. It provides a high-quality, open source Java toolkit that is designed to be used both in its entirety, as well as for its individual components.
 
-Strata is also highly extensible. Its built-in coverage is implemented using exactly the same extension points as anybody else would use to add their own asset classes, integrate thier own quant library, or add new pricing measures. This can be done externally, without needing to change or recompile the Strata code.
+Strata is also highly extensible. Its built-in coverage is implemented using exactly the same extension points as anybody else would use to add their own asset classes, integrate their own quant library, or add new pricing measures. This can be done externally, without needing to change or recompile the Strata code.
 
 ## Who is Strata for?
 


### PR DESCRIPTION
This PR:
- Improves the the Product Coverage table to distinguish between measures that are not applicable and measures that have not yet been implemented. The layout is also improved.
- Clarifies some aspects of the market data documentation based on feedback.
- Fixes a couple of typos.
