### PR TITLE
Remove blank Calculation Rules page

### DIFF
--- a/guide/concepts/calculation_flow.md
+++ b/guide/concepts/calculation_flow.md
@@ -24,7 +24,7 @@ At its core, Strata operates at a trade level. The goal of the first stage is to
 
 Together, these calculation requirements will allow the _market environment_ to be built in the next stage, and the calculations to be executed in a later stage.
 
-The key input to this stage is the set of _calculation rules_. These completely determine which calculation functions are available for use, and they fill in the details of the market data those functions require. For more information, see [Calculation Rules]({{site.baseurl}}/calculation_rules/).
+The key input to this stage is the set of _calculation rules_. These completely determine which calculation functions are available for use, and they fill in the details of the market data those functions require.
 
 This stage is implemented by `CalculationRunner` in the methods `createCalculationConfig` and `createCalculationTasks`.
 

--- a/guide/concepts/calculation_rules.md
+++ b/guide/concepts/calculation_rules.md
@@ -1,6 +1,0 @@
----
-title: Calculation Rules
-permalink: /calculation_rules/
----
-
-

--- a/guide/extension_points/add_asset_class.md
+++ b/guide/extension_points/add_asset_class.md
@@ -6,7 +6,7 @@ Strata includes support for a range of common asset classes, but support for new
 
 * Define classes for the asset class
 * Write functions to calculate measures for the new asset class - see [this guide]({{site.baseurl}}/add_measure/).
-* Create pricing rules specifying how measures should be calculated for the new asset class - see [here]({{site.baseurl}}/calculation_rules/).
+* Create pricing rules specifying how measures should be calculated for the new asset class.
 
 ## Defining an Asset Class
 

--- a/guide/extension_points/add_measure.md
+++ b/guide/extension_points/add_measure.md
@@ -4,7 +4,7 @@ permalink: /add_measure/
 ---
 ## Measures
 
-In Strata, measures define the values that can be calculated for a trade or other calculation target. For example, Strata provides a standard set of measures including present value and PV01 (see the `Measure` class). When a user requests a calculation they specify the measures that should be calculated and the [rules]({{site.baseurl}}/calculation_rules/) defining how they should be calculated.
+In Strata, measures define the values that can be calculated for a trade or other calculation target. For example, Strata provides a standard set of measures including present value and PV01 (see the `Measure` class). When a user requests a calculation they specify the measures that should be calculated and the rules defining how they should be calculated.
 
 The set of measures calculated by Strata is extensible. Users can add new measures for the built-in asset classes and can also add support for the built-in measures for new asset classes.
 

--- a/guide/getting_started/command_line_tool.md
+++ b/guide/getting_started/command_line_tool.md
@@ -235,7 +235,7 @@ The fields are described below.
 
 Curve groups assign purposes to curves. For example, they allow a curve to be identified as a USD discounting curve, or a forecasting curve for 3-month Libor.
 
-The [market data rules]({{site.baseurl}}/calculation_rules) specify the name of the curve group to use for a given trade. In Strata 0.7, a fixed set of rules are used by the command-line tool which always use a single curve group with the name `Default`. The use of multiple curve groups would be the mechanism by which, for example, a different discounting curve could be used for different counterparties, or the same measure could be displayed side-by-side showing the effect of using different curves.
+The market data rules specify the name of the curve group to use for a given trade. In Strata 0.7, a fixed set of rules are used by the command-line tool which always use a single curve group with the name `Default`. The use of multiple curve groups would be the mechanism by which, for example, a different discounting curve could be used for different counterparties, or the same measure could be displayed side-by-side showing the effect of using different curves.
 
 There must be a single file called `groups.csv` which defines all available curve groups. This is a CSV-formatted file with the following header row:
 


### PR DESCRIPTION
This PR removes the placeholder _Calculation Rules_ page and the links to it in the current absence of content.
