### PR TITLE
Switch to Kramdown and Rouge

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,13 +5,13 @@ exclude: [Gemfile, LICENSE.txt, README.md, vendor]
 gems:
   - jekyll-sitemap
 
-markdown: redcarpet
-redcarpet:
-  extensions: ["smart", "autolink", "tables", "fenced_code_blocks", "no_intra_emphasis"]
+markdown: kramdown
+highlighter: rouge
+kramdown:
+  input: GFM
+  syntax_highlighter: rouge
 
 permalink: :title
-
-highlighter: pygments
 
 sass:
   sass_dir: assets/stylesheets

--- a/assets/stylesheets/syntax.css
+++ b/assets/stylesheets/syntax.css
@@ -1,22 +1,22 @@
 /* to make lines scroll instead of wrap */
 /* from http://stackoverflow.com/a/23393920 */
 
-.highlight pre code * {
+.highlighter-rouge pre code * {
   white-space: nowrap;    // this sets all children inside to nowrap
 }
 
-.highlight pre {
+.highlighter-rouge pre {
   overflow-x: auto;       // this sets the scrolling in x
 }
 
-.highlight pre code {
+.highlighter-rouge pre code {
   white-space: pre;       // forces <code> to respect <pre> formatting
 }
 
 /* github style pygments theme for jekyll */
 /* from https://github.com/aahan/pygments-github-style */
 
-.highlight pre, pre, .highlight .hll { background-color: #f8f8f8; border: 1px solid #ccc; padding: 6px 10px; border-radius: 3px; }
+.highlighter-rouge pre, pre, .highlight .hll { background-color: #f8f8f8; padding: 6px 10px; border-radius: 3px; }
 .highlight .c { color: #999988; font-style: italic; }
 .highlight .err { color: #a61717; background-color: #e3d2d2; }
 .highlight .k { font-weight: bold; }

--- a/pages/docs/products/bullet_payment.md
+++ b/pages/docs/products/bullet_payment.md
@@ -25,7 +25,7 @@ BulletPayment bp = BulletPayment.builder()
   .build();
 ```
 
-{{tip}}The `strata-loader` project provides the ability to load a bullet payment from FpML.{{end}}
+{{tip}}The strata-loader project provides the ability to load a bullet payment from FpML.{{end}}
 
 
 ## Pricing

--- a/pages/docs/products/fra.md
+++ b/pages/docs/products/fra.md
@@ -31,7 +31,7 @@ Fra fra = Fra.builder()
   .build();
 ```
 
-{{tip}}The `strata-loader` project provides the ability to load a FRA from FpML.{{end}}
+{{tip}}The strata-loader project provides the ability to load a FRA from FpML.{{end}}
 
 
 ## Pricing

--- a/pages/docs/products/swap.md
+++ b/pages/docs/products/swap.md
@@ -62,7 +62,7 @@ SwapLeg receiveLeg = RateCalculationSwapLeg.builder()
 Swap swap = Swap.of(payLeg, receiveLeg);
 ```
 
-{{tip}}The `strata-loader` project provides the ability to load a swap from FpML.{{end}}
+{{tip}}The strata-loader project provides the ability to load a swap from FpML.{{end}}
 
 
 

--- a/pages/docs/products/term_deposit.md
+++ b/pages/docs/products/term_deposit.md
@@ -33,7 +33,7 @@ TermDeposit td = TermDeposit.builder()
   .build();
 ```
 
-{{tip}}The `strata-loader` project provides the ability to load a term deposit from FpML.{{end}}
+{{tip}}The strata-loader project provides the ability to load a term deposit from FpML.{{end}}
 
 
 ## Pricing


### PR DESCRIPTION
Maintain long-term compatibility with GitHub pages:
- Switch to Kramdown for Markdown parser (required from 1 May 2016)
- Switch to Rouge for syntax highlighting (already substituted automatically)

Preview: http://ci-docs.opengamma.com/strata/topic/kramdown/
